### PR TITLE
Crossing audit: Ignore by default

### DIFF
--- a/web/src/crossings/AuditCrossingsMode.svelte
+++ b/web/src/crossings/AuditCrossingsMode.svelte
@@ -12,7 +12,7 @@
   import type { Feature, FeatureCollection } from "geojson";
   import { emptyGeojson } from "svelte-utils/map";
 
-  let ignoreServiceRoads = false;
+  let ignoreServiceRoads = true;
 
   $: data = JSON.parse(
     $backend!.auditCrossings(ignoreServiceRoads),


### PR DESCRIPTION
I think the default should be to ignore the service roads to focus on main roads first

> <img width="416" height="204" alt="image" src="https://github.com/user-attachments/assets/5d4b91ae-ace3-4653-9438-5a3d737379ee" />
