### PR TITLE
Visualize per-side road tagging. #11

### DIFF
--- a/web/src/sidewalks/WaysLayer.svelte
+++ b/web/src/sidewalks/WaysLayer.svelte
@@ -162,6 +162,37 @@
   />
 </GeoJSON>
 
+{#key ways}
+  <GeoJSON
+    data={$backend ? JSON.parse($backend.getRoadSides()) : emptyGeojson()}
+  >
+    <SymbolLayer
+      minzoom={16}
+      paint={{
+        "text-color": "white",
+        "text-halo-color": constructMatchExpression(
+          ["get", "sidewalks"],
+          {
+            "✓": "green",
+            X: "red",
+            "?": "pink",
+          },
+          "cyan",
+        ),
+        "text-halo-width": 4,
+      }}
+      layout={{
+        "text-field": ["get", "sidewalks"],
+        "text-size": 13,
+        "symbol-placement": "line",
+        "symbol-spacing": 30,
+        "text-allow-overlap": true,
+        "text-rotation-alignment": "viewport",
+      }}
+    />
+  </GeoJSON>
+{/key}
+
 <GeoJSON data={pinnedWaySides}>
   <SymbolLayer
     id="pinned-sides"


### PR DESCRIPTION
A possible solution to #11. Now it's quick to spot a purple road with explicit no sidewalks on one side:

<img width="1915" height="709" alt="image" src="https://github.com/user-attachments/assets/28ea0b94-5afc-4875-b164-ff54fffff284" />
<img width="1905" height="856" alt="image" src="https://github.com/user-attachments/assets/f2befa22-70e3-4a9f-877c-ab61a756bd13" />

I'm not sure whether just 3 states (yes, no, unknown) is the right number to show though. Consider this:
<img width="1905" height="856" alt="image" src="https://github.com/user-attachments/assets/f7f4d53e-6691-4a54-baa9-a316c7465018" />
Green checks on both sides, but on the left side, the sidewalk is tagged yes, not separate. Ideally we'd distinguish this?

Styling ideas very much welcome. And maybe this extra view is distracting and should be toggleable? I'll merge and ask for feedback.