### PR TITLE
Add `track` to the ignore-`service`-roads feautre

### DIFF
--- a/backend/src/audit.rs
+++ b/backend/src/audit.rs
@@ -11,12 +11,12 @@ use crate::{
 };
 
 impl Speedwalk {
-    pub fn audit_crossings(&self, ignore_service_roads: bool) -> Result<String> {
+    pub fn audit_crossings(&self, ignore_utility_roads: bool) -> Result<String> {
         let mut features = Vec::new();
 
         let graph = Graph::new(self);
 
-        for junction in self.find_junctions(ignore_service_roads, &graph) {
+        for junction in self.find_junctions(ignore_utility_roads, &graph) {
             let mut f = self
                 .mercator
                 .to_wgs84_gj(&graph.intersections[&junction.i].point);
@@ -61,7 +61,7 @@ impl Speedwalk {
     }
 
     /// Find all junctions along severances
-    fn find_junctions(&self, ignore_service_roads: bool, graph: &Graph) -> Vec<Junction> {
+    fn find_junctions(&self, ignore_utility_roads: bool, graph: &Graph) -> Vec<Junction> {
         let mut junctions = Vec::new();
         for (i, intersection) in &graph.intersections {
             if self.derived_nodes[&intersection.osm_node]
@@ -81,7 +81,7 @@ impl Speedwalk {
                 if way.is_severance() {
                     any_severances = true;
                 }
-                if ignore_service_roads && way.tags.is("highway", "service") {
+                if ignore_utility_roads && way.tags.is_any("highway", vec!["service", "track"]) {
                     continue;
                 }
                 arms.push(*e);

--- a/backend/src/wasm.rs
+++ b/backend/src/wasm.rs
@@ -294,8 +294,8 @@ impl Speedwalk {
     }
 
     #[wasm_bindgen(js_name = auditCrossings)]
-    pub fn audit_crossings_wasm(&self, ignore_service_roads: bool) -> Result<String, JsValue> {
-        self.audit_crossings(ignore_service_roads)
+    pub fn audit_crossings_wasm(&self, ignore_utility_roads: bool) -> Result<String, JsValue> {
+        self.audit_crossings(ignore_utility_roads)
             .map_err(err_to_js)
     }
 

--- a/web/src/crossings/AuditCrossingsMode.svelte
+++ b/web/src/crossings/AuditCrossingsMode.svelte
@@ -13,11 +13,11 @@
   import { emptyGeojson } from "svelte-utils/map";
   import SharedSidebarFooter from "../common/SharedSidebarFooter.svelte";
 
-  let ignoreServiceRoads = true;
+  let ignoreUtilityRoads = false;
 
   $: data = $backend
     ? (JSON.parse(
-        $backend!.auditCrossings(ignoreServiceRoads),
+        $backend!.auditCrossings(ignoreUtilityRoads),
       ) as FeatureCollection)
     : emptyGeojson();
   $: completeJunctions = data.features.filter(
@@ -52,7 +52,12 @@
       junctions have all possible crossings mapped
     </p>
 
-    <Checkbox bind:checked={ignoreServiceRoads}>Ignore service roads</Checkbox>
+    <Checkbox bind:checked={ignoreUtilityRoads}>
+      Ignore <code>service</code>
+      ,
+      <code>track</code>
+       roads
+    </Checkbox>
 
     {#if hovered}
       <p class="mt-5">


### PR DESCRIPTION
Please consider this PR more of an issue-report with wording suggestions in code. 
I did not have time to run or test it.
 
---

The issue:

The flag "ignore service roads" works great to reduce the cases, but it also need to look at `track`

For track the same rules apply: Generally we cont expect explicit crossings there; we expect pedestrians to use the centerline to walk and cross if possible but usually with "informal" crossings.

Examples:
* <img width="1135" height="554" alt="image" src="https://github.com/user-attachments/assets/3502ce6c-6d21-4eba-b861-6566e34761c5" />
* https://a-b-street.github.io/speedwalk/#17.78/52.765255/13.315906
* https://www.openstreetmap.org/way/350428885/history#map=18/52.764893/13.316924

