### PR TITLE
(Issue): URL states for the modes; and map

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@fortawesome/fontawesome-free": "^7.1.0",
         "bootstrap": "^5.3.8",
+        "nuqs-svelte": "^1.2.2",
         "osm-api": "^3.3.0",
         "svelte-maplibre": "github:dabreegster/svelte-maplibre#svelte4_popups",
         "svelte-utils": "github:a-b-street/svelte-utils",
@@ -35,6 +36,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
       "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -609,6 +611,7 @@
       "version": "0.3.12",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.12.tgz",
       "integrity": "sha512-OuLGC46TjB5BbN1dH8JULVVZY4WTdkF7tV9Ys6wLL1rubZnCMstOhNHueU5bLCrnRuDhKPDM4g6sw4Bel5Gzqg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -619,6 +622,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -628,12 +632,14 @@
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.4.tgz",
       "integrity": "sha512-VT2+G1VQs/9oz078bLrYbecdZKs912zQlkelYpuf+SXF+QvZDYJlbx/LSx+meSAwdDFnF8FVXW92AVjjkVmgFw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.29",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.29.tgz",
       "integrity": "sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -763,17 +769,6 @@
         "svelte": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@popperjs/core": {
-      "version": "2.11.8",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
-      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/popperjs"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -1256,6 +1251,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/geojson": {
@@ -1335,6 +1331,7 @@
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -1361,6 +1358,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
       "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.4"
@@ -1370,6 +1368,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
       "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 0.4"
@@ -1486,6 +1485,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/code-red/-/code-red-1.0.4.tgz",
       "integrity": "sha512-7qJWqItLA8/VPVlKJlFXU+NBlo/qyfs39aJcuMT/2ere32ZqvF5OSxgdM5xOfJJ7O429gg2HM47y8v9P+9wrNw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.4.15",
@@ -1506,6 +1506,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
       "integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mdn-data": "2.0.30",
@@ -1642,6 +1643,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
       "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
@@ -1899,6 +1901,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
       "integrity": "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.6"
@@ -1980,12 +1983,14 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
       "integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/magic-string": {
       "version": "0.30.17",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
       "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0"
@@ -2077,6 +2082,7 @@
       "version": "2.0.30",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
       "integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
+      "dev": true,
       "license": "CC0-1.0"
     },
     "node_modules/min-indent": {
@@ -2110,6 +2116,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "license": "MIT"
     },
     "node_modules/mkdirp": {
       "version": "0.5.6",
@@ -2176,6 +2188,30 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/nuqs-svelte": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/nuqs-svelte/-/nuqs-svelte-1.2.2.tgz",
+      "integrity": "sha512-9iQ9Aas0eNvfjcEnYLMUQTd7ERtmk39idT53hNOWd7i1YS9IMAkA7xEwwo/x0GAT/fIOpvtGacvxam1ouijR1A==",
+      "license": "MIT",
+      "dependencies": {
+        "mitt": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/rtrampox"
+      },
+      "peerDependencies": {
+        "@sveltejs/kit": ">=2.16.0",
+        "svelte": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -2226,6 +2262,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/periscopic/-/periscopic-3.1.0.tgz",
       "integrity": "sha512-vKiQ8RRtkl9P+r/+oefh25C3fhybptkHKCZSPlcXiJux2tJF55GnEj3BVn4A5gKfq9NWWXXrxkHBwVPUfH0opw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0",
@@ -2488,6 +2525,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -2537,6 +2575,7 @@
       "version": "4.2.20",
       "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.2.20.tgz",
       "integrity": "sha512-eeEgGc2DtiUil5ANdtd8vPwt9AgaMdnuUFnPft9F5oMvU/FHu5IHFic+p1dR/UOB7XU2mX2yHW+NcTch4DCh5Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "^2.2.1",

--- a/web/package.json
+++ b/web/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "^7.1.0",
     "bootstrap": "^5.3.8",
+    "nuqs-svelte": "^1.2.2",
     "osm-api": "^3.3.0",
     "svelte-maplibre": "github:dabreegster/svelte-maplibre#svelte4_popups",
     "svelte-utils": "github:a-b-street/svelte-utils",

--- a/web/src/common/NavBar.svelte
+++ b/web/src/common/NavBar.svelte
@@ -1,17 +1,21 @@
 <script lang="ts">
   import Auth from "./Auth.svelte";
   import logo from "../../assets/logo.svg?url";
-  import { type Mode, mode, backend } from "../";
+  import { backend } from "../";
   import { Modal } from "svelte-utils";
+  import { useModeState, type ModeValue } from "../modeState";
 
   let showInfo = false;
 
-  let mainActions = [
-    [{ kind: "sidewalks" }, "Sidewalks"],
-    [{ kind: "crossings" }, "Crossings"],
-    [{ kind: "disconnections" }, "Network disconnections"],
-    [{ kind: "export" }, "Export"],
-  ] as [Mode, string][];
+  const modeState = useModeState();
+  $: currentMode = modeState.current;
+
+  let mainActions: [ModeValue, string][] = [
+    ["sidewalks", "Sidewalks"],
+    ["crossings", "Crossings"],
+    ["disconnections", "Network disconnections"],
+    ["export", "Export"],
+  ];
 </script>
 
 <ul class="nav nav-underline">
@@ -19,14 +23,14 @@
   <h3>Speedwalk</h3>
 
   {#if $backend}
-    {#each mainActions as [setMode, label]}
+    {#each mainActions as [modeValue, label]}
       <li class="nav-item">
         <!-- svelte-ignore a11y-invalid-attribute -->
         <a
           class="nav-link"
           href="#"
-          on:click={() => ($mode = setMode)}
-          class:active={JSON.stringify($mode) == JSON.stringify(setMode)}
+          on:click={() => modeState.set(modeValue)}
+          class:active={currentMode === modeValue}
         >
           {label}
         </a>

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -11,14 +11,6 @@ export let loggedInUser: Writable<
   { name: string; uid: number; avatarUrl: string } | undefined
 > = writable();
 
-export type Mode =
-  | { kind: "sidewalks" }
-  | { kind: "crossings" }
-  | { kind: "disconnections" }
-  | { kind: "export" };
-
-export let mode: Writable<Mode> = writable({ kind: "sidewalks" });
-
 export let enabledBulkOps = writable(false);
 export let debugMode = writable(false);
 

--- a/web/src/mapViewport.ts
+++ b/web/src/mapViewport.ts
@@ -1,0 +1,51 @@
+import { useQueryState, createParser } from "nuqs-svelte";
+
+export const roundNumber = (number: number, precision: number) => {
+  return Number.parseFloat(number.toFixed(precision));
+};
+
+export type MapViewport = {
+  zoom: number;
+  lat: number;
+  lng: number;
+};
+
+const mapViewportParser = createParser<MapViewport>({
+  parse(query: string) {
+    const parts = query.split("/");
+    if (parts.length !== 3) {
+      return null;
+    }
+    const zoom = Number.parseFloat(parts[0]);
+    const lat = Number.parseFloat(parts[1]);
+    const lng = Number.parseFloat(parts[2]);
+    if (
+      isNaN(zoom) ||
+      isNaN(lat) ||
+      isNaN(lng) ||
+      zoom < 0 ||
+      lat < -90 ||
+      lat > 90 ||
+      lng < -180 ||
+      lng > 180
+    ) {
+      return null;
+    }
+    return { zoom, lat, lng };
+  },
+  serialize(value: MapViewport) {
+    const zoom = roundNumber(value.zoom, 2);
+    const lat = roundNumber(value.lat, 6);
+    const lng = roundNumber(value.lng, 6);
+    return `${zoom}/${lat}/${lng}`;
+  },
+});
+
+export function useMapViewport() {
+  return useQueryState(
+    "map",
+    mapViewportParser.withOptions({
+      history: "replace",
+    }),
+  );
+}

--- a/web/src/modeState.ts
+++ b/web/src/modeState.ts
@@ -1,0 +1,18 @@
+import { useQueryState, parseAsStringLiteral } from "nuqs-svelte";
+
+export const modes = [
+  "sidewalks",
+  "crossings",
+  "disconnections",
+  "export",
+] as const;
+
+export type ModeValue = typeof modes[number];
+
+const modeParser = parseAsStringLiteral(modes).withDefault("sidewalks");
+
+export function useModeState() {
+  return useQueryState("mode", modeParser.withOptions({
+    history: "push",
+  }));
+}


### PR DESCRIPTION
Right now, its hard to share and reload the app because the app state is not preserved in the URL.
There is something going on when loading/reloading the app that resets the URL state of the map as well.

My common solution is, to push all relevant state to the URL and use NUQS for this. NUQS has some great helpers to manage state internally and push / read it to the URL. However, NUQS is not for svelte https://github.com/47ng/nuqs/discussions/1013, but there is https://github.com/rtrampox/nuqs-svelte
However, it looks like maybe nuqs-svelte only work with SvelteKit? (its the only one listed [as an adapter](https://github.com/rtrampox/nuqs-svelte?tab=readme-ov-file#adapters))

I looked into migrating the mode and URL state to nuqs-svelte, but got stuck on the Svelte 4 vs. Svelte 5 setup.

Before I look into this some more, I wanted to stop and first check what you think about the general idea…
I hear that migrating to svelte 5 is not super easy but also the app is not too big…

I looked into migrating this to Svelte 5 but both your map component but especially your utils library rely on Svelte 4 so the update does not work well.

Side note: This code right now would not work because it is missing the 

A next step for this migration would have been to migrate more internal states to the URL. Candidates are…
- the sidewalk-qa-modes (from the dropdown)
- the "about panel open" state
