### PR TITLE
Share the refetch-data between modes

### DIFF
--- a/web/src/DisconnectionsMode.svelte
+++ b/web/src/DisconnectionsMode.svelte
@@ -8,12 +8,14 @@
   } from "svelte-maplibre";
   import type { MapMouseEvent, ExpressionSpecification } from "maplibre-gl";
   import { SplitComponent } from "svelte-utils/top_bar_layout";
-  import { constructMatchExpression } from "svelte-utils/map";
+  import { constructMatchExpression, emptyGeojson } from "svelte-utils/map";
   import { backend, map, prettyPrintDistance, networkFilter } from "./";
   import NetworkFilter from "./common/NetworkFilter.svelte";
   import SharedSidebarFooter from "./common/SharedSidebarFooter.svelte";
 
-  $: gj = JSON.parse($backend!.findConnectedComponents($networkFilter));
+  $: gj = $backend
+    ? JSON.parse($backend!.findConnectedComponents($networkFilter))
+    : { ...emptyGeojson(), component_lengths: [] };
 
   let colors = ["#1b9e77", "#d95f02", "#7570b3", "#e7298a", "#66a61e"];
   let colorByComponent = constructMatchExpression(

--- a/web/src/ExportMode.svelte
+++ b/web/src/ExportMode.svelte
@@ -7,13 +7,15 @@
     QualitativeLegend,
   } from "svelte-utils";
   import { SplitComponent } from "svelte-utils/top_bar_layout";
-  import { constructMatchExpression } from "svelte-utils/map";
+  import { constructMatchExpression, emptyGeojson } from "svelte-utils/map";
   import { backend, networkFilter } from "./";
   import CollapsibleCard from "./common/CollapsibleCard.svelte";
   import NetworkFilter from "./common/NetworkFilter.svelte";
   import SharedSidebarFooter from "./common/SharedSidebarFooter.svelte";
 
-  $: gj = JSON.parse($backend!.exportNetwork($networkFilter));
+  $: gj = $backend
+    ? JSON.parse($backend!.exportNetwork($networkFilter))
+    : emptyGeojson();
 
   function download() {
     downloadGeneratedFile("network.geojson", JSON.stringify(gj));

--- a/web/src/common/SharedSidebarFooter.svelte
+++ b/web/src/common/SharedSidebarFooter.svelte
@@ -1,10 +1,8 @@
 <script lang="ts">
   import * as backendPkg from "../../../backend/pkg";
-  import { backend, refreshLoadingScreen } from "../";
+  import { backend, refreshLoadingScreen, anyEdits } from "../";
   import { overpassQueryForPolygon } from "svelte-utils/overpass";
   import { Loading } from "svelte-utils";
-
-  export let anyEdits: boolean = false;
 
   let loading = "";
 
@@ -39,7 +37,7 @@
 
   function clear() {
     if (
-      anyEdits &&
+      $anyEdits &&
       !window.confirm(
         "Changing areas will discard your current edits. Do you want to clear the edits?",
       )
@@ -47,11 +45,12 @@
       return;
     }
     $backend = null;
+    $anyEdits = false;
   }
 
   async function refreshData() {
     if (
-      anyEdits &&
+      $anyEdits &&
       !window.confirm(
         "Refreshing OSM data will discard your current edits. Do you want to clear the edits?",
       )

--- a/web/src/crossings/AuditCrossingsMode.svelte
+++ b/web/src/crossings/AuditCrossingsMode.svelte
@@ -15,9 +15,11 @@
 
   let ignoreServiceRoads = true;
 
-  $: data = JSON.parse(
-    $backend!.auditCrossings(ignoreServiceRoads),
-  ) as FeatureCollection;
+  $: data = $backend
+    ? (JSON.parse(
+        $backend!.auditCrossings(ignoreServiceRoads),
+      ) as FeatureCollection)
+    : emptyGeojson();
   $: completeJunctions = data.features.filter(
     (f) => f.properties!.complete,
   ).length;

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -6,6 +6,7 @@ import type { Map } from "maplibre-gl";
 export let map: Writable<Map | null> = writable(null);
 export let backend: Writable<backendPkg.Speedwalk | null> = writable(null);
 export let mutationCounter = writable(0);
+export let anyEdits = writable(false);
 
 export let loggedInUser: Writable<
   { name: string; uid: number; avatarUrl: string } | undefined

--- a/web/src/sidewalks/Edits.svelte
+++ b/web/src/sidewalks/Edits.svelte
@@ -6,10 +6,9 @@
     loggedInUser,
     mutationCounter,
     refreshLoadingScreen,
+    anyEdits,
   } from "../";
   import { uploadChangeset } from "osm-api";
-
-  export let anyEdits: boolean;
 
   let cmds: any[] = [];
   let idx = 0;
@@ -18,7 +17,7 @@
   $: if ($mutationCounter > 0) {
     cmds = $backend ? JSON.parse($backend.getEdits()) : [];
     idx = 0;
-    anyEdits = cmds.length > 0;
+    $anyEdits = cmds.length > 0;
   }
 
   function prev() {
@@ -96,6 +95,7 @@
       // Clear the entire state -- since upstream OSM was just updated, make
       // people re-import the area
       $backend = null;
+      $anyEdits = false;
     } catch (err) {
       window.alert(`Upload failed: ${err}`);
     }

--- a/web/src/sidewalks/SidewalksMode.svelte
+++ b/web/src/sidewalks/SidewalksMode.svelte
@@ -54,8 +54,6 @@
   >;
   let showRoadSides = false;
 
-  let anyEdits = false;
-
   let loading = "";
 
   let drawProblems = emptyGeojson();
@@ -115,7 +113,7 @@
 
 <SplitComponent>
   <div slot="sidebar">
-    <Edits bind:anyEdits />
+    <Edits />
 
     <ProblemControls {nodes} {ways} bind:drawProblems />
 
@@ -125,7 +123,7 @@
 
     <BulkOperations />
 
-    <SharedSidebarFooter {anyEdits} />
+    <SharedSidebarFooter />
   </div>
 
   <div slot="map">


### PR DESCRIPTION
The sidewalk mode has buttons to change the data; but the other modes did not.

This extract the two buttons and status line into a shared component that is added to the bottom of the sidebar for all modes.

---

- <img width="706" height="645" alt="Bildschirmfoto 2025-12-15 um 13 22 48" src="https://github.com/user-attachments/assets/815478b3-01a0-487d-8b85-24fda442e60f" />
- <img width="749" height="425" alt="Bildschirmfoto 2025-12-15 um 13 22 50" src="https://github.com/user-attachments/assets/8bd7de78-194f-49c2-bb95-b17f87b9b7f8" />
- <img width="755" height="1306" alt="Bildschirmfoto 2025-12-15 um 13 22 54" src="https://github.com/user-attachments/assets/18aabc76-f432-4bee-bea1-5935ffceab03" />
- <img width="767" height="1028" alt="Bildschirmfoto 2025-12-15 um 13 22 57" src="https://github.com/user-attachments/assets/521f9873-3519-4c8b-95d3-7008fe182884" />
- 