### PR TITLE
Search for crossings along the entire way, not just the first graph

### DIFF
--- a/web/src/AuditCrossingsMode.svelte
+++ b/web/src/AuditCrossingsMode.svelte
@@ -17,11 +17,13 @@
     only_major_roads: true,
     ignore_utility_roads: true,
     ignore_cycleways: true,
+    max_distance: 30,
   };
 
-  $: data = $backend
-    ? (JSON.parse($backend!.auditCrossings(options)) as FeatureCollection)
-    : emptyGeojson();
+  $: data =
+    $backend && options.max_distance
+      ? (JSON.parse($backend!.auditCrossings(options)) as FeatureCollection)
+      : emptyGeojson();
   $: completeJunctions = data.features.filter(
     (f) => f.properties!.complete,
   ).length;
@@ -73,14 +75,32 @@
       <code>track</code>
       roads
     </Checkbox>
-    <Checkbox bind:checked={options.ignore_cycleways}>Ignore cycleways</Checkbox>
+    <Checkbox bind:checked={options.ignore_cycleways}>
+      Ignore cycleways
+    </Checkbox>
+    <div>
+      <label class="form-label">
+        How far away can a crossing be? (m):
+        <input
+          class="form-control"
+          type="number"
+          min="1"
+          max="100"
+          bind:value={options.max_distance}
+        />
+      </label>
+    </div>
 
     <div class="card card-body">
-      <QualitativeLegend labelColors={colors} itemsPerRow={1} />
+      <QualitativeLegend
+        labelColors={colors}
+        itemsPerRow={1}
+        swatchClass="circle"
+      />
     </div>
 
     {#if hovered}
-      <p class="mt-3 mb-3">
+      <p class="mt-3">
         Junction has {debugArms.features.length - numberDCSplits} arms
         {#if numberDCSplits > 0}
           ({numberDCSplits} dual carriageway {numberDCSplits == 1
@@ -93,7 +113,14 @@
           , {explicitNonCrossingCount} explicit {explicitNonCrossingCount == 1
             ? "non-crossing"
             : "non-crossings"}
-        {/if}
+        {/if}.
+      </p>
+      <p class="mb-3">
+        <i>
+          Arms are up to {options.max_distance}m away from the junction along
+          the same OSM way. If the way is split before a crossing, the crossing
+          won't be counted. Only the first crossing is counted per arm.
+        </i>
       </p>
     {/if}
 


### PR DESCRIPTION
edge, stopping up to some distance away from the junction. #49, #27

Around `#17.17/52.41439/13.494402` is looking better. As long as the OSM way isn't split between the junction node and the crossing node, we'll find it within the distance threshold:
<img width="1920" height="1080" alt="Screenshot 2025-12-17 at 11 23 42 (2)" src="https://github.com/user-attachments/assets/a30dbd16-9f6b-4081-83d9-0001e4bbe3b4" />
<img width="1920" height="1080" alt="Screenshot 2025-12-17 at 11 24 08 (2)" src="https://github.com/user-attachments/assets/ff8cadea-1f3b-4fd6-8d05-86300dd7add4" />

An example of finding a crossing very far away (I set 300m just to show it works):
<img width="1920" height="1080" alt="Screenshot 2025-12-17 at 11 25 30 (2)" src="https://github.com/user-attachments/assets/3e8448de-6090-48ac-b92f-2e7247703398" />

#48 still isn't solved, depending how ways are split. The ideal approach is still to detect the full extent of a junction and only have one junction, instead of two nodes:
<img width="1920" height="1080" alt="Screenshot 2025-12-17 at 11 28 17 (2)" src="https://github.com/user-attachments/assets/45889f75-7b02-463c-8549-adf628ef9a72" />
