### PR TITLE
Ignore footways in the crossing audit. #43, #44

### DIFF
--- a/backend/src/audit.rs
+++ b/backend/src/audit.rs
@@ -17,6 +17,7 @@ pub struct Options {
     only_major_roads: bool,
     ignore_utility_roads: bool,
     ignore_cycleways: bool,
+    ignore_footways: bool,
     max_distance: f64,
 }
 
@@ -102,6 +103,9 @@ impl Speedwalk {
                     continue;
                 }
                 if options.ignore_cycleways && way.tags.is("highway", "cycleway") {
+                    continue;
+                }
+                if options.ignore_footways && way.tags.is_any("highway", vec!["footway", "path"]) {
                     continue;
                 }
                 if way.kind.is_road() {

--- a/web/src/AuditCrossingsMode.svelte
+++ b/web/src/AuditCrossingsMode.svelte
@@ -17,6 +17,7 @@
     only_major_roads: true,
     ignore_utility_roads: true,
     ignore_cycleways: true,
+    ignore_footways: true,
     max_distance: 30,
   };
 
@@ -77,6 +78,9 @@
     </Checkbox>
     <Checkbox bind:checked={options.ignore_cycleways}>
       Ignore cycleways
+    </Checkbox>
+    <Checkbox bind:checked={options.ignore_footways}>
+      Ignore <code>footway</code> and <code>path</code>
     </Checkbox>
     <div>
       <label class="form-label">


### PR DESCRIPTION
I think some of the detailed cases in #43 and #44 all get resolved with a simple rule -- don't treat footway and path as an arm.
<img width="1129" height="697" alt="Screenshot 2025-12-17 at 16 06 10" src="https://github.com/user-attachments/assets/dd0a84df-9c2b-43f5-bdd5-4ba251f09145" />
<img width="952" height="653" alt="Screenshot 2025-12-17 at 16 06 37" src="https://github.com/user-attachments/assets/7f433cda-525e-4293-82ef-154d3ebf6fc4" />

https://www.openstreetmap.org/node/63033657#map=19/52.727776/13.240368 doesn't count as a junction at all, because the node is tagged as a crossing.