### PR TITLE
Increase max_distance from 30 to 40

### DIFF
--- a/web/src/crossings/AuditCrossingsMode.svelte
+++ b/web/src/crossings/AuditCrossingsMode.svelte
@@ -24,7 +24,7 @@
     ignore_footways: true,
     ignore_roundabouts: true,
     ignore_motorways: true,
-    max_distance: 30,
+    max_distance: 40,
   });
 
   let data = $derived(


### PR DESCRIPTION
In https://github.com/a-b-street/speedwalk/issues/49#issuecomment-3660161510 we picked a distance for 30 meters where we stopped looking for crossings.

> I would say, we should only search for crossings within the first 30 meters of a crossing.

I found a case where this was just not enough due to the way the streets crossed at an angle:

<img width="691" height="586" alt="Image" src="https://github.com/user-attachments/assets/e003088f-b9b0-4f49-8af8-ca99d4f7ef96" />

* https://www.openstreetmap.org/edit?editor=id#map=20/52.7654074/13.2531228
* https://a-b-street.github.io/speedwalk/#18.65/52.7654724/13.2531421

I think picking 40 ist just as save and should resolve those edge cases.

---

I this the right value? I did not run the code locally…