### PR TITLE
Export: Add length to Map Popup

### DIFF
--- a/backend/src/export.rs
+++ b/backend/src/export.rs
@@ -100,6 +100,7 @@ impl Speedwalk {
                 }
 
                 f.set_property("kind", format!("{:?}", way.kind));
+                f.set_property("length", Euclidean.length(&edge.linestring));
 
                 for (k, v) in &way.tags.0 {
                     f.set_property(k.to_string(), v.to_string());

--- a/web/src/ExportMode.svelte
+++ b/web/src/ExportMode.svelte
@@ -4,7 +4,7 @@
   import { downloadGeneratedFile, QualitativeLegend } from "svelte-utils";
   import { SplitComponent } from "svelte-utils/top_bar_layout";
   import { constructMatchExpression, emptyGeojson } from "svelte-utils/map";
-  import { backend, networkFilter } from "./";
+  import { backend, networkFilter, prettyPrintDistance } from "./";
   import CollapsibleCard from "./common/CollapsibleCard.svelte";
   import NetworkFilter from "./common/NetworkFilter.svelte";
 
@@ -120,6 +120,9 @@
                 {/each}
               </tbody>
             </table>
+            <div style="margin-top: 8px;">
+              <strong>Length:</strong> {(data!.properties!.length as number | undefined) != null ? prettyPrintDistance(data!.properties!.length) : "-"}
+            </div>
           {/snippet}
         </Popup>
       </LineLayer>


### PR DESCRIPTION
I needed a way to quickly see the length of a way segment while understanding the export.
This adds it to the existing Popup.

* before 
    <img width="366" height="423" alt="Bildschirmfoto 2026-01-26 um 13 02 51" src="https://github.com/user-attachments/assets/64c7e11f-a361-4470-a590-5e11e1585d24" />
* after 
    <img width="340" height="465" alt="Bildschirmfoto 2026-01-26 um 13 03 32" src="https://github.com/user-attachments/assets/33ec5723-1fab-492e-aae7-de9a82d9c164" />
