### PR TITLE
Store some settings in local storage

### DIFF
--- a/web/src/common/LoadAnotherArea.svelte
+++ b/web/src/common/LoadAnotherArea.svelte
@@ -12,10 +12,12 @@
     Loading,
     Modal,
   } from "svelte-utils";
+  import { localStorageStore } from "./localStorage";
+  import LocalStorageWrapper from "./LocalStorageWrapper.svelte";
 
   let show = $state(false);
   let loading = $state("");
-  let saveCopy = $state(false);
+  let saveCopy = localStorageStore("saveCopy", false);
 
   function describeOsmTimestamp(t: bigint | undefined): string {
     if (t) {
@@ -78,7 +80,7 @@
       let resp = await fetchOverpass(overpassQueryForPolygon(boundary));
       let osmXml = await resp.bytes();
 
-      if (saveCopy) {
+      if ($saveCopy) {
         let text = new TextDecoder().decode(osmXml);
         downloadGeneratedFile("refreshed_import.osm.xml", text);
       }
@@ -110,9 +112,11 @@
       Refresh OSM data
     </button>
 
-    <Checkbox bind:checked={saveCopy}>
-      Save a copy of the latest osm.xml after refreshing
-    </Checkbox>
+    <LocalStorageWrapper>
+      <Checkbox bind:checked={$saveCopy}>
+        Save a copy of the latest osm.xml after refreshing
+      </Checkbox>
+    </LocalStorageWrapper>
 
     <OverpassServerSelector />
   </div>

--- a/web/src/common/LocalStorageWrapper.svelte
+++ b/web/src/common/LocalStorageWrapper.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  import type { Snippet } from "svelte";
+
+  let {
+    children,
+  }: {
+    children: Snippet;
+  } = $props();
+</script>
+
+<div style="display: flex; align-items: center; gap: 6px;">
+  {@render children()}
+  <i
+    class="fa-solid fa-hard-drive"
+    style="font-size: 0.85em; color: #6c757d; cursor: help; flex-shrink: 0;"
+    title="This setting is saved locally"
+    aria-label="This setting is saved locally"
+  ></i>
+</div>

--- a/web/src/common/localStorage.ts
+++ b/web/src/common/localStorage.ts
@@ -1,0 +1,43 @@
+import { type Writable, writable } from "svelte/store";
+
+/**
+ * Creates a localStorage-backed writable store.
+ * The value is automatically synced with localStorage on every change.
+ * On initialization, the value is loaded from localStorage if available.
+ */
+export function localStorageStore<T>(
+  key: string,
+  defaultValue: T,
+): Writable<T> {
+  const storageKey = `speedwalk_${key}`;
+
+  // Try to read initial value from localStorage
+  let initialValue = defaultValue;
+  try {
+    const stored = localStorage.getItem(storageKey);
+    if (stored !== null) {
+      initialValue = JSON.parse(stored) as T;
+    }
+  } catch (err) {
+    console.warn(`Failed to read ${storageKey} from localStorage:`, err);
+  }
+
+  // Create the store
+  const store = writable<T>(initialValue);
+
+  // Subscribe to changes and write to localStorage
+  store.subscribe((value) => {
+    try {
+      localStorage.setItem(storageKey, JSON.stringify(value));
+    } catch (err) {
+      // Handle quota exceeded or other localStorage errors
+      if (err instanceof DOMException && err.name === "QuotaExceededError") {
+        console.warn(`localStorage quota exceeded for ${storageKey}`);
+      } else {
+        console.warn(`Failed to write ${storageKey} to localStorage:`, err);
+      }
+    }
+  });
+
+  return store;
+}

--- a/web/src/crossings/BulkOperations.svelte
+++ b/web/src/crossings/BulkOperations.svelte
@@ -7,6 +7,7 @@
     enabledBulkOps,
     refreshLoadingScreen,
   } from "../";
+  import LocalStorageWrapper from "../common/LocalStorageWrapper.svelte";
 
   let { options }: { options: any } = $props();
 
@@ -50,7 +51,9 @@
 {/if}
 
 <Modal bind:show>
-  <h2>Bulk operations</h2>
+  <LocalStorageWrapper>
+    <h2>Bulk operations</h2>
+  </LocalStorageWrapper>
 
   <p>
     Speedwalk has some experimental features that can automatically generate

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -2,6 +2,7 @@ import { type Writable, writable } from "svelte/store";
 import * as backendPkg from "../../backend/pkg";
 import type { Map } from "maplibre-gl";
 import { basemapStyles } from "svelte-utils/map";
+import { localStorageStore } from "./common/localStorage";
 
 export let map: Writable<Map | null> = writable(null);
 export let backend: Writable<backendPkg.Speedwalk | null> = writable(null);
@@ -20,7 +21,7 @@ export type Mode =
 
 export let mode: Writable<Mode> = writable({ kind: "sidewalks" });
 
-export let enabledBulkOps = writable(false);
+export let enabledBulkOps = localStorageStore("enabledBulkOps", false);
 export let debugMode = writable(false);
 
 export let networkFilter = writable<{

--- a/web/src/sidewalks/BulkOperations.svelte
+++ b/web/src/sidewalks/BulkOperations.svelte
@@ -7,6 +7,7 @@
     enabledBulkOps,
     refreshLoadingScreen,
   } from "../";
+  import LocalStorageWrapper from "../common/LocalStorageWrapper.svelte";
 
   let show = $state(false);
   function enableOps() {
@@ -107,7 +108,9 @@
 {/if}
 
 <Modal bind:show>
-  <h2>Bulk operations</h2>
+  <LocalStorageWrapper>
+    <h2>Bulk operations</h2>
+  </LocalStorageWrapper>
 
   <p>
     Speedwalk has some experimental features that can automatically generate


### PR DESCRIPTION
I find my self wanting something will remember some settings that I forget or that are only useful once (bulk).

One way would be to store them in the OSM profile https://github.com/osmlab/osm-api-js/issues/32
But for now this would store them in the browser.

Not sure how well Svelte handles syncing the store like this, so maybe this needs a different approach. It's not that annoying though that I would spend too much time on it…

Right now, only those settings are migrated:
- enable bulk operations
- store xml

The icon is to explain to users what is going on…

<img width="660" height="415" alt="Bildschirmfoto 2026-01-26 um 14 34 06" src="https://github.com/user-attachments/assets/ba2b5f7e-1364-4e8d-bc4d-af13a430b4a0" />
<img width="583" height="295" alt="Bildschirmfoto 2026-01-26 um 14 35 10" src="https://github.com/user-attachments/assets/4be9d3e4-601f-48f8-97e5-57f5a06e0944" />

The "Save a copy of the osm.xml after importing" on the first screen is from the helper package, right? So no icon there, because its too hard :-).