### PR TITLE
When creating crossing geometry, if the perpendicular line fails, try…

### DIFF
--- a/backend/src/disconnected.rs
+++ b/backend/src/disconnected.rs
@@ -37,7 +37,8 @@ impl Speedwalk {
             let mut ways = BTreeSet::new();
             for i in nodes {
                 for e in &graph.intersections[&i].edges {
-                    if self.filter_network(filter, graph, &graph.edges[e], dead_end_edges.as_ref()) {
+                    if self.filter_network(filter, graph, &graph.edges[e], dead_end_edges.as_ref())
+                    {
                         ways.insert(graph.edges[e].osm_way);
                     }
                 }


### PR DESCRIPTION
… looking for the closest sidewalk point. Fixes #54 (the last idea mentioned there).

Fixes #83:
<img width="585" height="438" alt="Screenshot 2026-01-27 at 11 01 03" src="https://github.com/user-attachments/assets/67ec09d1-0d30-4650-bdcc-9161c89ffdda" />

Helps some cases of #69:
<img width="538" height="470" alt="Screenshot 2026-01-27 at 11 02 43" src="https://github.com/user-attachments/assets/4edf8bc8-a98d-46a5-bce7-be31eb367c52" />
<img width="510" height="439" alt="Screenshot 2026-01-27 at 11 02 59" src="https://github.com/user-attachments/assets/c3cd7e9f-47f7-4369-b21a-aa0ebb6f1d95" />

This approach isn't perfect, and still makes some mistakes, but it seems to be an overall improvement. I'm going to consolidate some of the remaining issues for crossing geometry after this.