### PR TITLE
Export: Round length property

### DIFF
--- a/backend/src/export.rs
+++ b/backend/src/export.rs
@@ -393,7 +393,8 @@ impl Speedwalk {
                 }
 
                 f.set_property("kind", format!("{:?}", way.kind));
-                f.set_property("length", Euclidean.length(&edge.linestring));
+                let length = Euclidean.length(&edge.linestring);
+                f.set_property("length", (length * 100.0).round() / 100.0);
 
                 for (k, v) in &way.tags.0 {
                     f.set_property(k.to_string(), v.to_string());


### PR DESCRIPTION
Follow up to 1c4a84a7c9acb198754e1e1bb9ad471dd340fa49

The frontend does the rounding nicely, but the geojson export has long values like  `"length": 7.853251393445136,` which we dont need…