### PR TITLE
Remove "save xml" settings from local storage again

### DIFF
--- a/web/src/common/LoadAnotherArea.svelte
+++ b/web/src/common/LoadAnotherArea.svelte
@@ -12,12 +12,10 @@
     Loading,
     Modal,
   } from "svelte-utils";
-  import { localStorageStore } from "./localStorage";
-  import LocalStorageWrapper from "./LocalStorageWrapper.svelte";
 
   let show = $state(false);
   let loading = $state("");
-  let saveCopy = localStorageStore("saveCopy", false);
+  let saveCopy = $state(false);
 
   function describeOsmTimestamp(t: bigint | undefined): string {
     if (t) {
@@ -80,7 +78,7 @@
       let resp = await fetchOverpass(overpassQueryForPolygon(boundary));
       let osmXml = await resp.bytes();
 
-      if ($saveCopy) {
+      if (saveCopy) {
         let text = new TextDecoder().decode(osmXml);
         downloadGeneratedFile("refreshed_import.osm.xml", text);
       }
@@ -112,11 +110,9 @@
       Refresh OSM data
     </button>
 
-    <LocalStorageWrapper>
-      <Checkbox bind:checked={$saveCopy}>
-        Save a copy of the latest osm.xml after refreshing
-      </Checkbox>
-    </LocalStorageWrapper>
+    <Checkbox bind:checked={saveCopy}>
+      Save a copy of the latest osm.xml after refreshing
+    </Checkbox>
 
     <OverpassServerSelector />
   </div>


### PR DESCRIPTION
Follow up to 52bc406986b7c7b9bc6573efbe77f70fbce1f23a

The option to store the settings does not work with the utils package easily so the "save xml" settings on the first screen behaved not differently to the one in the modal.

This removes the settings from the modal again so they are at least behaving the same.
(The local storage is still in place for other options…)

We could keep it, but I found it confusing to have it behave differently. But maybe that was just because I was expecting something different. – What do you thing?
