### PR TITLE
Add maxspeed enrichment and crossing node tag propagation

### DIFF
--- a/backend/src/edits.rs
+++ b/backend/src/edits.rs
@@ -8,7 +8,7 @@ use serde::Serialize;
 use utils::Tags;
 
 use crate::{
-    Kind, Node, Speedwalk, Way,
+    maxspeed, Kind, Node, Speedwalk, Way,
     graph::{Edge, Graph},
 };
 
@@ -306,6 +306,10 @@ pub enum UserCmd {
         node1: NodeID,
         node2: NodeID,
     },
+    /// Enrich all crossing ways with the maxspeed from the road they cross.
+    ApplyMaxspeed,
+    /// Enrich crossing ways with crossing tags from nodes that lie on them.
+    ApplyCrossingNodeTags,
 }
 
 pub enum TagCmd {
@@ -344,11 +348,11 @@ impl Edits {
             }
             UserCmd::MakeAllSidewalks(only_severances) => {
                 let results = model.make_all_sidewalks(only_severances);
-                self.create_new_geometry(results, model);
+                self.create_new_geometry(results, model)?;
             }
             UserCmd::ConnectAllCrossings(include_crossing_no) => {
                 let results = model.connect_all_crossings(include_crossing_no);
-                self.create_new_geometry(results, model);
+                self.create_new_geometry(results, model)?;
             }
             UserCmd::AssumeTags(drive_on_left) => {
                 for (id, way) in &model.derived_ways {
@@ -410,7 +414,7 @@ impl Edits {
                         modify_existing_way_tags: HashMap::new(),
                     },
                     model,
-                );
+                )?;
             }
             UserCmd::AddCrossingSegment(start_wgs84, end_wgs84, way_tags) => {
                 let snapped = snap_crossing_segment_with_way_ids(model, start_wgs84, end_wgs84)?;
@@ -435,7 +439,7 @@ impl Edits {
                         modify_existing_way_tags: HashMap::new(),
                     },
                     model,
-                );
+                )?;
             }
             UserCmd::AddCrossingSegmentSnapped {
                 start_way,
@@ -466,10 +470,135 @@ impl Edits {
                         modify_existing_way_tags: HashMap::new(),
                     },
                     model,
-                );
+                )?;
             }
             UserCmd::ManualDeleteEdge { way, node1, node2 } => {
                 self.manual_deleted_edges.insert((way, node1, node2));
+            }
+            UserCmd::ApplyMaxspeed => {
+                use geo::{BoundingRect, Intersects};
+                use rstar::AABB;
+
+                let road_rtree: RTree<GeomWithData<LineString, WayID>> =
+                    RTree::bulk_load(
+                        model
+                            .derived_ways
+                            .iter()
+                            .filter(|(_, way)| way.kind.is_road())
+                            .map(|(id, way)| GeomWithData::new(way.linestring.clone(), *id))
+                            .collect(),
+                    );
+
+                let crossings: Vec<(WayID, LineString, Tags)> = model
+                    .derived_ways
+                    .iter()
+                    .filter(|(_, way)| {
+                        way.kind == Kind::Crossing && !way.tags.has("maxspeed")
+                    })
+                    .map(|(id, way)| (*id, way.linestring.clone(), way.tags.clone()))
+                    .collect();
+
+                info!(
+                    "ApplyMaxspeed: {} crossings without maxspeed to process",
+                    crossings.len()
+                );
+
+                let mut enriched = 0usize;
+                let mut missing = 0usize;
+
+                for (crossing_id, linestring, tags) in crossings {
+                    let mut candidates: Vec<String> = Vec::new();
+
+                    // a) Direct lookup via tmp:osm_way_id (generated crossings)
+                    if let Some(ms) = tags.get("tmp:osm_way_id").and_then(|ref_str| {
+                        let raw_id: i64 =
+                            ref_str.strip_prefix("way/")?.parse().ok()?;
+                        let road = model.derived_ways.get(&WayID(raw_id))?;
+                        maxspeed::get_maxspeed_from_tags(&road.tags)
+                    }) {
+                        candidates.push(ms);
+                    }
+
+                    // b) Spatial lookup – ALL intersecting roads (handles dual
+                    // carriageways and crossings that span multiple road ways)
+                    for segment in linestring.lines() {
+                        let bbox = segment.bounding_rect();
+                        let aabb = AABB::from_corners(
+                            Point::new(bbox.min().x, bbox.min().y),
+                            Point::new(bbox.max().x, bbox.max().y),
+                        );
+                        for road_obj in road_rtree.locate_in_envelope_intersecting(&aabb) {
+                            if road_obj.geom().intersects(&linestring) {
+                                if let Some(road) = model.derived_ways.get(&road_obj.data) {
+                                    if let Some(ms) =
+                                        maxspeed::get_maxspeed_from_tags(&road.tags)
+                                    {
+                                        candidates.push(ms);
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    if let Some(ms_val) = maxspeed::pick_highest_maxspeed(&candidates) {
+                        self.change_way_tags
+                            .entry(crossing_id)
+                            .or_default()
+                            .push(TagCmd::Set("maxspeed".to_string(), ms_val));
+                        enriched += 1;
+                    } else {
+                        missing += 1;
+                    }
+                }
+
+                info!(
+                    "ApplyMaxspeed: enriched {} crossings, {} have no maxspeed data on crossed road",
+                    enriched, missing
+                );
+            }
+            UserCmd::ApplyCrossingNodeTags => {
+                const CROSSING_EXTRA_KEYS: &[&str] = &[
+                    "tactile_paving",
+                    "button_operated",
+                    "flashing_lights",
+                    "supervised",
+                ];
+
+                let crossings: Vec<(WayID, Vec<NodeID>, Tags)> = model
+                    .derived_ways
+                    .iter()
+                    .filter(|(_, way)| way.kind == Kind::Crossing)
+                    .map(|(id, way)| (*id, way.node_ids.clone(), way.tags.clone()))
+                    .collect();
+
+                let mut enriched = 0usize;
+                for (way_id, node_ids, way_tags) in crossings {
+                    let mut tags_to_add: Vec<(String, String)> = Vec::new();
+                    for node_id in &node_ids {
+                        if let Some(node) = model.derived_nodes.get(node_id) {
+                            for (k, v) in &node.tags.0 {
+                                let relevant = k.starts_with("crossing")
+                                    || CROSSING_EXTRA_KEYS.contains(&k.as_str());
+                                if relevant
+                                    && !way_tags.has(k)
+                                    && !tags_to_add.iter().any(|(tk, _)| tk == k)
+                                {
+                                    tags_to_add.push((k.clone(), v.clone()));
+                                }
+                            }
+                        }
+                    }
+                    if !tags_to_add.is_empty() {
+                        for (k, v) in tags_to_add {
+                            self.change_way_tags
+                                .entry(way_id)
+                                .or_default()
+                                .push(TagCmd::Set(k, v));
+                        }
+                        enriched += 1;
+                    }
+                }
+                info!("ApplyCrossingNodeTags: enriched {} crossing ways", enriched);
             }
         }
         Ok(())
@@ -486,7 +615,11 @@ impl Edits {
         Ok(())
     }
 
-    fn create_new_geometry(&mut self, results: CreateNewGeometry, model: &Speedwalk) {
+    fn create_new_geometry(
+        &mut self,
+        results: CreateNewGeometry,
+        model: &Speedwalk,
+    ) -> Result<()> {
         // TODO Or use+modify new_nodes immediately or something?
         let mut node_mapping: HashMap<HashedPoint, NodeID> = HashMap::new();
         // Insert all existing nodes. When we create crossing ways from a crossing node, we don't
@@ -497,8 +630,14 @@ impl Edits {
 
         // Modify existing ways first
         for (way_id, insert_points) in results.insert_new_nodes {
-            let mut node_ids = model.derived_ways[&way_id].node_ids.clone();
-            let mut linestring = model.derived_ways[&way_id].linestring.clone();
+            let way = model.derived_ways.get(&way_id).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "way {:?} no longer exists in derived_ways (stale override?)",
+                    way_id
+                )
+            })?;
+            let mut node_ids = way.node_ids.clone();
+            let mut linestring = way.linestring.clone();
 
             for (pt, tags) in insert_points {
                 let node_id = self.new_node_id();
@@ -581,6 +720,7 @@ impl Edits {
                 .or_insert_with(Vec::new)
                 .extend(cmds);
         }
+        Ok(())
     }
 
     pub fn to_osc(&self, model: &Speedwalk) -> String {

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -12,6 +12,7 @@ mod edits;
 mod export;
 mod graph;
 mod make_sidewalks;
+mod maxspeed;
 mod problems;
 mod scrape;
 mod wasm;

--- a/backend/src/maxspeed.rs
+++ b/backend/src/maxspeed.rs
@@ -1,0 +1,53 @@
+use utils::Tags;
+
+/// Determine effective maxspeed from OSM tags.
+/// - `maxspeed` directly → return it
+/// - `maxspeed:forward` + `maxspeed:backward` → return the higher original string
+/// - Anything else → None (no maxspeed info available)
+pub fn get_maxspeed_from_tags(tags: &Tags) -> Option<String> {
+    if let Some(v) = tags.get("maxspeed") {
+        return Some(v.clone());
+    }
+    match (tags.get("maxspeed:forward"), tags.get("maxspeed:backward")) {
+        (Some(fwd), Some(bwd)) => pick_highest_maxspeed(&[fwd.clone(), bwd.clone()]),
+        _ => None,
+    }
+}
+
+/// Given a list of raw maxspeed strings, return the one with the highest parsed km/h
+/// equivalent. Un-parseable strings (e.g. "DE:urban") are kept as fallback only if no
+/// numeric value is found.
+pub fn pick_highest_maxspeed(candidates: &[String]) -> Option<String> {
+    let mut best_str: Option<String> = None;
+    let mut best_val: Option<f64> = None;
+    let mut fallback: Option<String> = None;
+
+    for s in candidates {
+        match parse_maxspeed_value(s) {
+            Some(v) => {
+                if best_val.map_or(true, |b| v > b) {
+                    best_val = Some(v);
+                    best_str = Some(s.clone());
+                }
+            }
+            None => {
+                if fallback.is_none() {
+                    fallback = Some(s.clone());
+                }
+            }
+        }
+    }
+    best_str.or(fallback)
+}
+
+/// Parse the numeric part of a maxspeed value into a km/h equivalent.
+/// Supports formats like "50" or "30 mph" (number, optional space, optional unit).
+fn parse_maxspeed_value(s: &str) -> Option<f64> {
+    let mut parts = s.splitn(2, ' ');
+    let num: f64 = parts.next()?.trim().parse().ok()?;
+    match parts.next().map(|u| u.trim()) {
+        Some("mph") => Some(num * 1.60934),
+        _ => Some(num),
+    }
+}
+

--- a/backend/src/wasm.rs
+++ b/backend/src/wasm.rs
@@ -495,6 +495,24 @@ impl Speedwalk {
     /// Clear manual override commands (manual crossing adds + manual edge deletions), preserving all
     /// other edit commands.
     ///
+    #[wasm_bindgen(js_name = editApplyMaxspeed)]
+    pub fn edit_apply_maxspeed(&mut self) -> Result<(), JsValue> {
+        let mut edits = self.edits.take().unwrap();
+        let _ = edits.apply_cmd(UserCmd::ApplyMaxspeed, self);
+        self.edits = Some(edits);
+        self.after_edit();
+        Ok(())
+    }
+
+    #[wasm_bindgen(js_name = editApplyCrossingNodeTags)]
+    pub fn edit_apply_crossing_node_tags(&mut self) -> Result<(), JsValue> {
+        let mut edits = self.edits.take().unwrap();
+        let _ = edits.apply_cmd(UserCmd::ApplyCrossingNodeTags, self);
+        self.edits = Some(edits);
+        self.after_edit();
+        Ok(())
+    }
+
     /// Replays remaining commands one-by-one with `after_edit()` after each (same as [`edit_undo`]),
     /// so `apply_cmd` always sees a [`Speedwalk`] graph consistent with the command history.
     /// Batching with [`Edits::apply_cmds_without_rebuild`] against a stale derived graph can produce

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -20,6 +20,7 @@
   import ExportMode from "./ExportMode.svelte";
   import GeneratorMode from "./generator/GeneratorMode.svelte";
   import OverridesMode from "./overrides/OverridesMode.svelte";
+  import MaxspeedMode from "./crossings/MaxspeedMode.svelte";
   import StudyAreaFade from "./common/StudyAreaFade.svelte";
   import NavBar from "./common/NavBar.svelte";
 
@@ -144,6 +145,8 @@
                 <OverridesMode />
               {:else if $mode.kind == "export"}
                 <ExportMode />
+              {:else if $mode.kind == "maxspeed"}
+                <MaxspeedMode />
               {/if}
             {/key}
           {:else}

--- a/web/src/common/NavBar.svelte
+++ b/web/src/common/NavBar.svelte
@@ -22,6 +22,7 @@
     ...auditActions,
     [{ kind: "generator" }, "Generator"],
     [{ kind: "overrides" }, "Overrides"],
+    [{ kind: "maxspeed" }, "Maxspeed"],
     [{ kind: "export" }, "Export"],
   ] as [Mode, string][];
 

--- a/web/src/crossings/MaxspeedMode.svelte
+++ b/web/src/crossings/MaxspeedMode.svelte
@@ -1,0 +1,201 @@
+<script lang="ts">
+  import {
+    LineLayer,
+    GeoJSON,
+    hoverStateFilter,
+    Popup,
+    Control,
+  } from "svelte-maplibre";
+  import { SplitComponent } from "svelte-utils/top_bar_layout";
+  import { localStorageStore, Loading } from "svelte-utils";
+  import { backend, mutationCounter, refreshLoadingScreen } from "../";
+  import type { FeatureCollection } from "geojson";
+  import { emptyGeojson } from "svelte-utils/map";
+  import CollapsibleCard from "../common/CollapsibleCard.svelte";
+  import Jumbotron from "../common/Jumbotron.svelte";
+  import LegendList from "../common/LegendList.svelte";
+
+  type Unit = "auto" | "km/h" | "mph";
+
+  let unitOverride = localStorageStore<Unit>("maxspeed_unit", "auto");
+
+  let crossings = $derived.by(() => {
+    $mutationCounter;
+    if (!$backend) {
+      return emptyGeojson();
+    }
+    const gj = JSON.parse($backend.getWays()) as FeatureCollection;
+    gj.features = gj.features.filter(
+      (f) => f.properties!.kind === "Crossing",
+    );
+    for (const f of gj.features) {
+      const tags = f.properties!.tags ?? {};
+      const ms: string | undefined = tags.maxspeed;
+      f.properties!.maxspeed = ms ?? null;
+      f.properties!.maxspeed_num = ms ? parseFloat(ms) : null;
+    }
+    return gj;
+  });
+
+  let detectedUnit = $derived(
+    crossings.features.some((f) => f.properties!.maxspeed?.includes("mph"))
+      ? "mph"
+      : "km/h",
+  );
+
+  let unit = $derived($unitOverride === "auto" ? detectedUnit : $unitOverride);
+
+  const rect = { swatchClass: "rectangle" as const };
+  let legendItems = $derived(
+    unit === "mph"
+      ? [
+          { color: "#2ecc71", label: "≤ 20 mph", ...rect },
+          { color: "#f1c40f", label: "≤ 30 mph", ...rect },
+          { color: "#e74c3c", label: "> 30 mph", ...rect },
+          { color: "#aaaaaa", label: "No maxspeed", ...rect },
+        ]
+      : [
+          { color: "#2ecc71", label: "≤ 30 km/h", ...rect },
+          { color: "#f1c40f", label: "≤ 50 km/h", ...rect },
+          { color: "#e74c3c", label: "> 50 km/h", ...rect },
+          { color: "#aaaaaa", label: "No maxspeed", ...rect },
+        ],
+  );
+
+  let thresholds = $derived(unit === "mph" ? [20, 30] : [30, 50]);
+
+  let crossingsWithMaxspeed = $derived(
+    crossings.features.filter((f) => f.properties!.maxspeed !== null).length,
+  );
+
+  let crossingsWithoutMaxspeed = $derived(
+    crossings.features.length - crossingsWithMaxspeed,
+  );
+
+  let loading = $state("");
+
+  async function applyMaxspeed() {
+    loading = "Applying maxspeed to crossings";
+    await refreshLoadingScreen();
+    try {
+      $backend!.editApplyMaxspeed();
+      $mutationCounter++;
+    } catch (err) {
+      window.alert(`Error: ${err}`);
+    } finally {
+      loading = "";
+    }
+  }
+</script>
+
+<Loading {loading} />
+
+<SplitComponent>
+  {#snippet left()}
+    <Jumbotron
+      title="Maxspeed"
+      lead="Enriches crossing ways with the maxspeed attribute of the crossed road. When a crossing spans more than one road, the highest speed limit among all crossed roads is used."
+    >
+      <p class="mb-0 small text-muted">
+        {crossingsWithMaxspeed.toLocaleString()} of {crossings.features.length.toLocaleString()}
+        crossings already have a maxspeed attribute.
+      </p>
+      {#if crossingsWithoutMaxspeed > 0}
+        <p class="mb-0 small text-muted">
+          {crossingsWithoutMaxspeed.toLocaleString()} crossings have no maxspeed because of missing data on road.
+        </p>
+      {/if}
+    </Jumbotron>
+
+    <div class="mb-3">
+      <p class="form-label small text-muted mb-1">
+        Unit
+        {#if $unitOverride === "auto"}
+          <span class="text-secondary">(auto-detected: {detectedUnit})</span>
+        {/if}
+      </p>
+      <div class="btn-group btn-group-sm d-block">
+        <button
+          class="btn btn-outline-secondary"
+          class:active={$unitOverride === "auto"}
+          onclick={() => ($unitOverride = "auto")}
+        >
+          Auto
+        </button>
+        <button
+          class="btn btn-outline-secondary"
+          class:active={$unitOverride === "km/h"}
+          onclick={() => ($unitOverride = "km/h")}
+        >
+          km/h
+        </button>
+        <button
+          class="btn btn-outline-secondary"
+          class:active={$unitOverride === "mph"}
+          onclick={() => ($unitOverride = "mph")}
+        >
+          mph
+        </button>
+      </div>
+    </div>
+
+    <button class="btn btn-primary mb-3" onclick={applyMaxspeed}>
+      Apply maxspeed to all crossings
+    </button>
+  {/snippet}
+
+  {#snippet main()}
+    <GeoJSON data={crossings} generateId>
+      <LineLayer
+        manageHoverState
+        paint={{
+          "line-width": 5,
+          "line-opacity": hoverStateFilter(0.6, 1.0),
+          "line-color": [
+            "case",
+            ["==", ["get", "maxspeed_num"], null],
+            "#aaaaaa",
+            ["<=", ["get", "maxspeed_num"], thresholds[0]],
+            "#2ecc71",
+            ["<=", ["get", "maxspeed_num"], thresholds[1]],
+            "#f1c40f",
+            "#e74c3c",
+          ],
+        }}
+        hoverCursor="pointer"
+      >
+        <Popup openOn="hover">
+          {#snippet children({ data })}
+            {@const props = data?.properties ?? {}}
+            <table class="table table-bordered table-sm mb-0">
+              <tbody>
+                <tr>
+                  <td>maxspeed</td>
+                  <td>{props.maxspeed ?? "–"}</td>
+                </tr>
+                {#if props.tags}
+                  {@const tags = props.tags}
+                  {#if tags.crossing}
+                    <tr>
+                      <td>crossing</td>
+                      <td>{tags.crossing}</td>
+                    </tr>
+                  {/if}
+                {/if}
+              </tbody>
+            </table>
+          {/snippet}
+        </Popup>
+      </LineLayer>
+    </GeoJSON>
+
+    <Control position="top-right">
+      <CollapsibleCard>
+        {#snippet header()}Legend{/snippet}
+        {#snippet body()}
+          <LegendList items={legendItems} />
+        {/snippet}
+      </CollapsibleCard>
+    </Control>
+  {/snippet}
+</SplitComponent>

--- a/web/src/generator/GeneratorBulkOperations.svelte
+++ b/web/src/generator/GeneratorBulkOperations.svelte
@@ -89,6 +89,19 @@
       loading = "";
     }
   }
+
+  async function applyCrossingNodeTags() {
+    loading = "Enriching crossings with node tags";
+    await refreshLoadingScreen();
+    try {
+      $backend!.editApplyCrossingNodeTags();
+      $mutationCounter++;
+    } catch (err) {
+      window.alert(`Error: ${err}`);
+    } finally {
+      loading = "";
+    }
+  }
 </script>
 
 <Loading {loading} />
@@ -157,6 +170,20 @@
     </LocalStorageWrapper>
     <button class="btn btn-secondary" onclick={connectAllCrossings}>
       Create a way for every crossing node
+    </button>
+  </div>
+</div>
+
+<div class="card mb-3">
+  <div class="card-header">Enrich crossings with node tags</div>
+  <div class="card-body">
+    <p class="small text-muted mb-2">
+      Transfers <code>crossing=*</code>, <code>crossing:island</code>,
+      <code>tactile_paving</code> and related tags from OSM crossing nodes onto
+      their crossing ways, for better routing scores.
+    </p>
+    <button class="btn btn-secondary" onclick={applyCrossingNodeTags}>
+      Apply crossing node tags
     </button>
   </div>
 </div>

--- a/web/src/index.ts
+++ b/web/src/index.ts
@@ -19,13 +19,15 @@ export type Mode =
   | { kind: "disconnections" }
   | { kind: "generator" }
   | { kind: "export" }
-  | { kind: "overrides" };
+  | { kind: "overrides" }
+  | { kind: "maxspeed" };
 
 /** Mode kinds only available when use case is "route-networks". When switching to audit, redirect off these. */
 export const ROUTE_NETWORK_ONLY_MODE_KINDS: Mode["kind"][] = [
   "generator",
   "overrides",
   "export",
+  "maxspeed",
 ];
 
 export const DEFAULT_AUDIT_MODE: Mode = { kind: "sidewalks" };


### PR DESCRIPTION
## Summary

Two new bulk operations for improving crossing way data quality, accessible via a new **Maxspeed** app mode and buttons in the Generator page:

- **ApplyMaxspeed**: Enriches crossing ways with the `maxspeed` of the road they cross. Uses a spatial R-tree lookup to handle dual carriageways and crossings spanning multiple road ways. Also does a direct lookup via `tmp:osm_way_id` for generated crossings where the source road is already known.

- **ApplyCrossingNodeTags**: Propagates crossing-related tags (`crossing=*`, `crossing:island`, `tactile_paving`, `button_operated`, `flashing_lights`, `supervised`) from OSM crossing nodes onto their crossing ways. Useful for better routing scores in downstream consumers.

Both operations are exposed as WASM bindings (`editApplyMaxspeed`, `editApplyCrossingNodeTags`) and as buttons in the Generator page. A dedicated **Maxspeed** page provides a map view and workflow for the maxspeed enrichment.

Also fixes `create_new_geometry` to return `Result<()>` so callers can properly propagate errors instead of panicking on stale way references.

## Test plan

- [ ] Load an area with generated crossings → Generator page → "Apply crossing node tags" → verify `crossing=*` tags from nodes appear on crossing ways in the export
- [ ] Load an area → Maxspeed page → "Apply maxspeed" → verify crossing ways in the export have `maxspeed=*` matching the crossed road
- [ ] Test with a dual carriageway crossing — both road ways should contribute maxspeed candidates; the highest value should win

🤖 Generated with [Claude Code](https://claude.com/claude-code)